### PR TITLE
& in the achievement name would resolve the html syntax wrong

### DIFF
--- a/GUI.lua
+++ b/GUI.lua
@@ -1759,6 +1759,7 @@ function Instance_OnClick(self)
                     button.contentText:SetFont("Fonts\\FRIZQT__.TTF", 12);
                 end
                 local achievementLink = GetAchievementLink(instanceLocation["boss" .. counter2].achievement)
+		achievementLink = achievementLink:gsub("&", "&amp;"); -- & in the achievement name would resolve the html syntax wrong
                 if core.achievementTrackingEnabled == false then
 		            button.contentText:SetText("<html><body><p>" .. L["GUI_Achievement"] .. ": " .. achievementLink .. "<br /><br />" .. tacticsStr .. "</p></body></html>")
                 else


### PR DESCRIPTION
Noticed this for Vault of Archavon 10 and 25 man achievement.