### PR TITLE
Fix conflict with FriendsFrame group invite drop down.

### DIFF
--- a/GUI.lua
+++ b/GUI.lua
@@ -1356,6 +1356,7 @@ function Config:CreateGUI()
     local buttonHeight = 30
     local numButtons = 200 --Total number of button we need for any instance. We can hide excess button for raids/dungeons with less bosses
     local idCounter = 0
+    local button
     for j = 2, 8 do
         local globalCounter = 1
         for i = 1, numButtons do


### PR DESCRIPTION
The variable named `button` in `Config:CreateGUI()` is not declared local.

This naming conflicts with Blizzard's `FriendsFrame`, preventing a drop-down to select the friend's character from showing next to the "Invite to group" button, if the friend is logged into multiple accounts.

See the full context of the `button` variable in `FriendsFrame` here: 
https://www.townlong-yak.com/framexml/43022/FriendsFrame.lua#2322

Snippet included for reference:
```
-- if no button, now find the physical friend button to anchor the dropdown
-- it might not exist if the list was scrolled
if ( not button ) then
    local buttons = FriendsListFrameScrollFrame.buttons;
    for i = 1, #buttons do
        if ( buttons[i].id == friendIndex and buttons[i].buttonType == FRIENDS_BUTTON_TYPE_BNET ) then
            button = buttons[i];
            break;
        end
    end
end
```

Due to `button` not being local, in both `Config:CreateGUI()` and `FriendsFrame_BattlenetInviteByIndex`, the condition always evaluates `true` and therefore attempts to attach the character selector drop-down to an IAT created frame.