### PR TITLE
Bump interface for Cata

### DIFF
--- a/InstanceAchievementTracker.toc
+++ b/InstanceAchievementTracker.toc
@@ -1,5 +1,5 @@
 ﻿## Interface: 110005
-## Interface-Cata: 40400
+## Interface-Cata: 40401
 ## Notes: An addon for tracking the completion/faliure of instance achievements.
 ## Title:Instance Achievement Tracker
 ## Author: Whizzey


### PR DESCRIPTION
Missed this one. Maybe InstanceAchievementTracker_Cata.toc is not necessary anymore?